### PR TITLE
Begin marking assertions with the conformance statements they cover.

### DIFF
--- a/check_coverage.py
+++ b/check_coverage.py
@@ -1,0 +1,91 @@
+"""
+Usage
+python3 check_coverage.py <path to spec html>
+"""
+
+import sys
+
+from html.parser import HTMLParser
+
+
+def print_usage():
+  print("python3 check_coverage.py <path to spec html> <path to tested ids>")
+
+
+class ConformanceStatementFinder(HTMLParser):
+  """Finds all conformance statements tagged in the spec."""
+
+  def __init__(self):
+    super().__init__()
+    self.in_span = False
+    self.conformance_ids = set()
+
+  def handle_starttag(self, tag, attrs):
+    if tag != "span":
+      return
+
+    attr_map = {a[0]: a[1] for a in attrs}
+    if "id" not in attr_map or "class" not in attr_map:
+      return
+
+    if "conform" not in attr_map["class"]:
+      return
+    if "server" not in attr_map["class"]:
+      return
+
+    self.conformance_ids.add(attr_map["id"])
+
+  def handle_endtag(self, tag):
+    pass
+
+  def handle_data(self, data):
+    pass
+
+  def error(self, message):
+    pass
+
+
+def run(html_path, tested_ids_path):
+  """Report which conformance statements are not being tested."""
+  with open(html_path, "r", encoding='utf-8') as html_file:
+    html_text = html_file.read()
+
+  finder = ConformanceStatementFinder()
+  finder.feed(html_text)
+  spec_ids = finder.conformance_ids
+  tested_ids = tested_conformance_ids(tested_ids_path)
+
+  untested_ids = spec_ids - tested_ids
+  if len(untested_ids) > 0:
+    print("Conformance statements in Spec that are not tested:")
+    for i in untested_ids:
+      print(i)
+  print("")
+
+  missing_from_spec = tested_ids - spec_ids
+  if len(missing_from_spec) > 0:
+    print("Tested IDs that are not in the spec:")
+    for i in missing_from_spec:
+      print(i)
+
+
+def tested_conformance_ids(tested_ids_path):
+  """Loads the test of ids which have been tested."""
+  with open(tested_ids_path, "r", encoding='utf-8') as tested_ids_file:
+    tested_ids_text = tested_ids_file.readlines()
+
+  ids = set()
+  line_start = "tested conformance id: "
+  for line in tested_ids_text:
+    if line.startswith(line_start):
+      ids.add(line[len(line_start):-1])
+
+  return ids
+
+
+if __name__ == '__main__':
+  if len(sys.argv) != 3:
+    print_usage()
+    sys.exit()
+
+  run(sys.argv[1], sys.argv[2])

--- a/response_checker.py
+++ b/response_checker.py
@@ -35,6 +35,7 @@ class ResponseChecker:
   """Defines a set of common checks against a IFT server response."""
 
   def __init__(self, test_case, response):
+    """Constructor."""
     self.test_case = test_case
     self.status_code = response.status
     self.response_data = response.read()

--- a/response_checker.py
+++ b/response_checker.py
@@ -40,8 +40,14 @@ class ResponseChecker:
     self.response_data = response.read()
     self.response_obj = None
     self.url = response.url
+    self.tested_ids = set()
+
+  def print_tested_ids(self):
+    for tag in self.tested_ids:
+      print(f"tested conformance id: {tag}")
 
   def conform_message(self, tag, message):
+    self.tested_ids.add(tag)
     return (f"Failed requirement {spec_link(tag)}\n"
             f"  {message}\n"
             f"  Request URL: {self.url}")
@@ -87,6 +93,7 @@ class ResponseChecker:
 
     # TODO(garretrieger): test checksums
     # TODO(garretrieger): font shapes identical to original for subset codepoints.
+    return self
 
   def response(self):
     """Returns the decoded cbor response object."""

--- a/response_checker.py
+++ b/response_checker.py
@@ -27,6 +27,10 @@ BROTLI = 1
 PATCH_FORMATS = {VCDIFF, BROTLI}
 
 
+def spec_link(tag):
+  return f"https://w3c.github.io/IFT/Overview.html#{tag}"
+
+
 class ResponseChecker:
   """Defines a set of common checks against a IFT server response."""
 
@@ -37,6 +41,11 @@ class ResponseChecker:
     self.response_obj = None
     self.url = response.url
 
+  def conform_message(self, tag, message):
+    return (f"Failed requirement {spec_link(tag)}\n"
+            f"  {message}\n"
+            f"  Request URL: {self.url}")
+
   def successful_response_checks(self):
     """Checks all of the invariants that should be true on a successful response."""
     self.test_case.assertEqual(
@@ -44,7 +53,8 @@ class ResponseChecker:
         f"Status code must be success (200) for {self.url} (2.5)")
     self.test_case.assertEqual(
         self.response_data[:4], bytes([0x49, 0x46, 0x54, 0x20]),
-        f"Missing magic number 'IFT ' for {self.url} (2.5)")
+        self.conform_message("conform-magic-number",
+                             "Missing magic number 'IFT '"))
 
     self.response_well_formed()
     return self

--- a/test_server.py
+++ b/test_server.py
@@ -68,7 +68,7 @@ class ServerConformanceTest(unittest.TestCase):
   def test_minimal_request_post(self):
     response = self.request(self.font_path, data=ValidRequests.MINIMAL_REQUEST)
     (response.successful_response_checks().format_in(
-        {VCDIFF}).check_apply_patch_to(None, {0x41}))
+        {VCDIFF}).check_apply_patch_to(None, {0x41}).print_tested_ids())
 
 
 if __name__ == '__main__':

--- a/test_server.py
+++ b/test_server.py
@@ -67,8 +67,8 @@ class ServerConformanceTest(unittest.TestCase):
   # TODO(garretrieger): test for GET.
   def test_minimal_request_post(self):
     response = self.request(self.font_path, data=ValidRequests.MINIMAL_REQUEST)
-    (response.successful_response_checks().format_is(
-        VCDIFF).check_apply_patch_to(None, {0x41}))
+    (response.successful_response_checks().format_in(
+        {VCDIFF}).check_apply_patch_to(None, {0x41}))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Assertions are marked by reference the statements id. Also adds a utility which reports any ids that are missing tests, or ids which are not present in the spec.